### PR TITLE
Add right margin when icons are displayed

### DIFF
--- a/css/sm-civicrm.css
+++ b/css/sm-civicrm.css
@@ -15,6 +15,9 @@
 label.crm-quickSearchField {
   color: #fff;
 }
+#civicrm-menu i {
+  margin-right: 5px;
+}
 .sm-civicrm li {
 	padding: 0;
 }


### PR DESCRIPTION
If icons are available in the menu they need to be spaced apart from the label.  This adds a css selector (the same as is used in core) to do that.

See: https://github.com/civicrm/civicrm-core/pull/13020

![localhost_8000_civicrm_dashboard_reset 1](https://user-images.githubusercontent.com/2052161/47607337-609f7a00-da16-11e8-9cb4-4885108a9ef8.png)
