### PR TITLE
Joomla-specific padding/positioning fixes

### DIFF
--- a/css/sm-civicrm.css
+++ b/css/sm-civicrm.css
@@ -231,3 +231,30 @@ li#crm-qsearch ul {
     margin: 0;
   }
 }
+
+/* Joomla Specific Fixes */
+
+body.admin.com_civicrm ul#civicrm-menu li#crm-qsearch {
+	height: 1px;
+}
+body.admin.com_civicrm ul#civicrm-menu li#crm-qsearch a {
+	padding: 3px 0 0 0;
+}
+@media (max-width: 768px) {
+	body.admin.com_civicrm #civicrm-menu-nav {
+		position: inherit;
+		}
+	body.admin.com_civicrm {
+		margin-top: 0 !important;
+	}
+	body.admin.com_civicrm .container-fluid.container-main {
+		margin: 0 -20px;
+	}
+	body.admin.com_civicrm .main-menu-btn {
+		top: 5px;
+	}
+	body.admin.com_civicrm ul#civicrm-menu {
+		top: 17px;
+		margin: 0;
+	}
+}


### PR DESCRIPTION
Solves the CSS-specific issues described here: https://github.com/aydun/uk.squiffle.kam/issues/12

Full width:
![image](https://user-images.githubusercontent.com/1175967/48198419-b813e300-e350-11e8-9a0c-b314434c5979.png)

Responsive (closed):
![image](https://user-images.githubusercontent.com/1175967/48198451-d548b180-e350-11e8-8383-9c111a10abca.png)

Responsive (open):
![image](https://user-images.githubusercontent.com/1175967/48198482-e7c2eb00-e350-11e8-82db-bce51860c5e9.png)

Changes are using Joomla-specific classes so shouldn't impact any other CMS. NB, the responsive dropdown still has overlapping issues. However until the javascript issue is resolved maybe best not to do further CSS tweaks in case that fixes some anyway. Not tested with Shoreditch.

Regarding the JS error "Empty string passed to getElementById()" — the Joomla dropdown menu is also broken in mobile viewport on Civi pages. So I wonder (total guess) if there is JS running on the `<nav>` element, and because both CRM and CMS are using` <nav>` for the menu it's confusing things. 