### PR TITLE
Lighter color scheme and toggle button

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Menubar placement can be configured at **Administer -> Customize Data & Screens 
 | `crmMenuLoad` | Triggered on the page body after menu data loads but *before* the menu is rendered in the dom.<br />This is a good time to add/remove items if you already know what they are at page load. | `$(document).on('crmMenuLoad', function() {` <br /> `  CRM.menubar.addItems(-1, 'Search', myItems);` <br /> `});` | 
 | `crmLoad` | Triggered on the `#civicrm-menu` element after menu is rendered in the dom. | `$(document).on('crmLoad', '#civicrm-menu', function() {` <br /> ` // Do something now that the menu is rendered` <br /> `});` | 
 
+#### Properties
+
+| Property | Type | Description |
+| ------ | ----------- | ------- |
+| `attachTo` | String | jQuery selector of page element to attach menubar to. |
+| `position` | String | E.g. 'over-cms-menu', 'below-cms-menu', 'above-crm-container'. |
+| `settings` | Object | Settings to pass to SmartMenus during initialize. |
+
 #### Methods
 
 | Method | Description | Example |
@@ -46,16 +54,18 @@ Menubar placement can be configured at **Administer -> Customize Data & Screens 
 | `removeItem( itemName )` | Deletes an item from the menu (and all its children).<br />`itemName`: name of item to remove. | `CRM.menubar.removeItem('New Household');` |
 | `show( [speed] )` | Shows the menubar if hidden.<br />`speed`: if a number is given, a slidedown animation is used. | `CRM.menubar.show(250);` |
 | `spin( [spin] )`  | Spins the icon in the home menu.<br />`spin`: pass a boolean to start or stop the spinning, or pass no arguments to toggle. | `CRM.menubar.spin(true); // start` <br /> `CRM.menubar.spin(false); // stop` |
-| `updateItem( item )`  | Updates the properties of a menu item (label, url, separator, icon, etc.<br />`item`: object with at least a `name` plus properties to update. | `CRM.menubar.updateItem({name: 'Search', label: 'Find');` |
+| `togglePosition()`  | Toggles between 'over-cms-menu' and 'below-cms-menu'. | `CRM.menubar.togglePosition();` |
+| `updateItem( item )`  | Updates the properties of a menu item (label, url, separator, icon, etc.<br />`item`: object with at least a `name` plus properties to update. | `CRM.menubar.updateItem({name: 'Search', label: 'Find'});` |
 
 Tip: Try pasting those examples into your browser console.
 
 #### CSS classes
 
-*The following css classes are added to the page body when the menubar is initialized*
+*The following css classes are added to the page body*
 
 * `crm-menubar-visible` When the menubar is present and visible.
 * `crm-menubar-hidden` When the menubar is present but hidden via `CRM.menubar.hide()`.
+* `crm-menubar-wrapped` When the menu items have wrapped to a second line and the menubar is twice as tall.
 * Depending on which option is selected, the body will also have one of: `crm-menubar-over-cms-menu`, `crm-menubar-below-cms-menu`, `crm-menubar-above-crm-container`.
 
 #### Hooks

--- a/css/crm-menubar.css
+++ b/css/crm-menubar.css
@@ -158,6 +158,17 @@
   margin: 0 2px;
 }
 
+#civicrm-menu #crm-menubar-toggle-position {
+  float: right;
+}
+#civicrm-menu #crm-menubar-toggle-position a i {
+  opacity: .6;
+  margin: 0;
+}
+body.crm-menubar-over-cms-menu #crm-menubar-toggle-position a i {
+  transform: rotate(180deg);
+}
+
 @media (min-width: 768px) {
 
   /* Switch to desktop layout
@@ -305,6 +316,10 @@
 
   #sort_name_navigation {
     width: 14em !important;
+  }
+
+  #crm-menubar-toggle-position {
+    display: none;
   }
 
   /* Make sure we can click overlapped submenus in responsive mode */

--- a/css/crm-menubar.css
+++ b/css/crm-menubar.css
@@ -6,7 +6,7 @@
   font-size: 13px;
 }
 #civicrm-menu {
-  background-color: #ddd;
+  background-color: #f2f2f2;
 	width: 100%;
   z-index: 500;
   height: auto;
@@ -133,7 +133,7 @@
 
 #crm-qsearch form input.ui-autocomplete-input {
   background: #eaeaea url(BASE_URL/bower_components/select2/select2.png) no-repeat scroll right -23px;
-  border: 1px solid #aaa;
+  border: 1px solid #ccc;
   margin: 4px 4px 0;
   padding: 2px 16px 3px 2px;
   height: 20px;
@@ -162,8 +162,10 @@
   float: right;
 }
 #civicrm-menu #crm-menubar-toggle-position a i {
-  opacity: .6;
+  color: #888;
   margin: 0;
+  border-top: 2px solid #888;
+  font-size: 11px;
 }
 body.crm-menubar-over-cms-menu #crm-menubar-toggle-position a i {
   transform: rotate(180deg);
@@ -192,6 +194,10 @@ body.crm-menubar-over-cms-menu #crm-menubar-toggle-position a i {
     top: -99999px;
   }
 
+  #civicrm-menu {
+    border-bottom: 1px solid #ccc;
+  }
+
   body.crm-menubar-below-cms-menu > #civicrm-menu-nav #civicrm-menu {
     top: 30px;
   }
@@ -212,7 +218,7 @@ body.crm-menubar-over-cms-menu #crm-menubar-toggle-position a i {
   #civicrm-menu ul li a:focus,
   #civicrm-menu ul li a:hover,
   #civicrm-menu ul li a.highlighted {
-    background-color: #ddd;
+    background-color: #f2f2f2;
     color: #222;
   }
 
@@ -235,6 +241,10 @@ body.crm-menubar-over-cms-menu #crm-menubar-toggle-position a i {
   /* hide the menu in mobile view */
   #crm-menubar-state:not(:checked) ~ #civicrm-menu {
     display: none;
+  }
+  #civicrm-menu {
+    z-index: 100000;
+    background-color: #333;
   }
 	#civicrm-menu ul {
 		background-color: #444;
@@ -297,11 +307,6 @@ body.crm-menubar-over-cms-menu #crm-menubar-toggle-position a i {
     background: url(BASE_URL/i/logo_lg.png) no-repeat;
     background-size: 18px;
     top: 6px;
-  }
-  #civicrm-menu {
-    width: 100% !important;
-    z-index: 100000;
-    background-color: #333;
   }
   #crm-qsearch {
     text-align: center;

--- a/css/crm-menubar.css
+++ b/css/crm-menubar.css
@@ -6,7 +6,7 @@
   font-size: 13px;
 }
 #civicrm-menu {
-	background-color: #333;
+  background-color: #ddd;
 	width: 100%;
   z-index: 500;
   height: auto;
@@ -17,12 +17,12 @@
 }
 #civicrm-menu li {
   border: none;
-	padding: 0;
+  padding: 0;
 }
 #civicrm-menu li a {
-	padding: 6px 8px;
+  padding: 12px 8px;
   text-decoration: none;
-  color: #ddd;
+  color: #333;
   box-shadow: none;
   border: none;
 }
@@ -30,36 +30,24 @@
   cursor: default;
 }
 #civicrm-menu li li a {
-	padding: 6px 36px 6px 10px;
-  color: #eee;
+  padding: 6px 36px 6px 10px;
 }
-#civicrm-menu ul {
-	background-color: #333;
-  box-shadow: 1px 1px 7px rgba(0, 0, 0, 0.5);
+#civicrm-menu li.crm-menu-border-bottom:not(:last-child) {
+  border-bottom: 1px solid #bbb;
 }
-#civicrm-menu ul ul {
-	background-color: #444;
-}
-#civicrm-menu ul ul ul {
-	background-color: #555;
-}
-#civicrm-menu li.crm-menu-border-bottom {
-	border-bottom: 2px groove #888;
-}
-#civicrm-menu li.crm-menu-border-top {
-	border-top: 2px ridge #888;
+#civicrm-menu li:not(.crm-menu-border-bottom) + li.crm-menu-border-top {
+  border-top: 2px solid #bbb;
 }
 #civicrm-menu li a:focus,
 #civicrm-menu li a:hover,
 #civicrm-menu li a.highlighted {
-	text-decoration: none;
-	background-color: #676767;
-  color: #fff;
+  text-decoration: none;
+  background-color: #fff;
 }
 #civicrm-menu li li .sub-arrow:before {
   content: "\f0da";
 	font-family: 'FontAwesome';
-	color: #eee;
+  color: #666;
 	float: right;
 	margin-right: -25px;
 }
@@ -145,10 +133,10 @@
 
 #crm-qsearch form input.ui-autocomplete-input {
   background: #eaeaea url(BASE_URL/bower_components/select2/select2.png) no-repeat scroll right -23px;
-  border: 1px solid black;
-  margin: 0;
+  border: 1px solid #aaa;
+  margin: 4px 4px 0;
   padding: 2px 16px 3px 2px;
-  height: 17px;
+  height: 20px;
 }
 
 #crm-qsearch form input.ui-autocomplete-input:focus {
@@ -162,13 +150,12 @@
 }
 
 /* From css/civicrmNavigation.css */
-#civicrm-menu-nav .crm-logo-sm,
-.crm-container .crm-logo-sm {
+#civicrm-menu-nav .crm-logo-sm {
   background: url(BASE_URL/i/logo_sm.png) no-repeat;
   display: inline-block;
   width: 16px;
   height: 16px;
-  vertical-align: middle;
+  margin: 0 2px;
 }
 
 @media (min-width: 768px) {
@@ -198,8 +185,24 @@
     top: 30px;
   }
 
-  #civicrm-menu > li {
-    height: 30px;
+  #civicrm-menu ul {
+    background-color: #fff;
+    box-shadow: 0px 0px 2px 0 rgba(0,0,0,0.3);
+  }
+
+  #civicrm-menu > li > a {
+    height: 40px;
+  }
+
+  #civicrm-menu > li > a.highlighted {
+    z-index: 200000;
+  }
+
+  #civicrm-menu ul li a:focus,
+  #civicrm-menu ul li a:hover,
+  #civicrm-menu ul li a.highlighted {
+    background-color: #ddd;
+    color: #222;
   }
 
   body.crm-menubar-over-cms-menu #civicrm-menu,
@@ -237,12 +240,19 @@
 	#civicrm-menu li a {
 		text-align: center;
 		font-size: 14px;
+    color: #ddd;
 	}
+  #civicrm-menu li a:focus,
+  #civicrm-menu li a:hover,
+  #civicrm-menu li a.highlighted {
+    background-color: #676767;
+    color: #fff;
+  }
   #civicrm-menu li .sub-arrow:before,
   #civicrm-menu li li .sub-arrow:before {
     content: "\f0da";
     font-family: 'FontAwesome';
-    color: #eee;
+    color: #bbb;
     float: none;
     margin-left: 10px;
   }
@@ -280,6 +290,7 @@
   #civicrm-menu {
     width: 100% !important;
     z-index: 100000;
+    background-color: #333;
   }
   #crm-qsearch {
     text-align: center;
@@ -290,6 +301,10 @@
 
   #civicrm-menu li[data-name="Hide Menu"] {
     display: none;
+  }
+
+  #sort_name_navigation {
+    width: 14em !important;
   }
 
   /* Make sure we can click overlapped submenus in responsive mode */

--- a/css/crm-menubar.css
+++ b/css/crm-menubar.css
@@ -51,12 +51,6 @@
 	float: right;
 	margin-right: -25px;
 }
-#civicrm-menu ul li:last-child a{
-	margin-bottom: 5px;
-}
-#civicrm-menu ul > li:first-child a{
-	margin-top: 5px;
-}
 /* x icon */
 #crm-menubar-state:checked ~ .crm-menubar-toggle-btn .crm-menubar-toggle-btn-icon {
   height: 0;

--- a/css/menubar-backdrop.css
+++ b/css/menubar-backdrop.css
@@ -1,7 +1,7 @@
 @media (min-width: 768px) {
 
   body.crm-menubar-visible.crm-menubar-below-cms-menu {
-    padding-top: 27px;
+    padding-top: 37px;
   }
   .admin-bar body.crm-menubar-below-cms-menu #civicrm-menu {
     position: absolute;

--- a/css/menubar-drupal7.css
+++ b/css/menubar-drupal7.css
@@ -1,29 +1,33 @@
 body.crm-menubar-visible.crm-menubar-over-cms-menu #toolbar-home,
-body.crm-menubar-visible.crm-menubar-over-cms-menu #toolbar-user {
-  visibility: hidden;
-}
 body.crm-menubar-visible.crm-menubar-over-cms-menu #toolbar-menu {
   display: none;
 }
 
 @media (min-width: 768px) {
 
+  body.crm-menubar-visible.crm-menubar-over-cms-menu #toolbar-user {
+    visibility: hidden;
+  }
+
+  body.crm-menubar-visible.crm-menubar-over-cms-menu {
+    padding-top: 40px !important;
+  }
+
+  body.crm-menubar-visible.crm-menubar-over-cms-menu #toolbar .toolbar-drawer {
+    display: none !important;
+  }
+
   body.toolbar.crm-menubar-visible.crm-menubar-below-cms-menu {
-    padding-top: 60px !important;
+    padding-top: 70px !important;
   }
   body.toolbar.toolbar-drawer.crm-menubar-visible.crm-menubar-below-cms-menu {
-    padding-top: 94px !important;
+    padding-top: 104px !important;
   }
 
   body.toolbar.crm-menubar-visible.crm-menubar-below-cms-menu #toolbar {
     -moz-box-shadow: none;
     -webkit-box-shadow: none;
     box-shadow: none;
-  }
-
-  body.toolbar.crm-menubar-below-cms-menu #civicrm-menu,
-  body.toolbar.crm-menubar-above-crm-container #civicrm-menu {
-    width: 100% !important;
   }
 
   body.toolbar.toolbar-drawer.crm-menubar-below-cms-menu #civicrm-menu {

--- a/css/menubar-drupal7.css
+++ b/css/menubar-drupal7.css
@@ -12,6 +12,9 @@ body.crm-menubar-visible.crm-menubar-over-cms-menu #toolbar-menu {
   body.crm-menubar-visible.crm-menubar-over-cms-menu {
     padding-top: 40px !important;
   }
+  body.crm-menubar-visible.crm-menubar-over-cms-menu.crm-menubar-wrapped {
+    padding-top: 80px !important;
+  }
 
   body.crm-menubar-visible.crm-menubar-over-cms-menu #toolbar .toolbar-drawer {
     display: none !important;
@@ -20,8 +23,15 @@ body.crm-menubar-visible.crm-menubar-over-cms-menu #toolbar-menu {
   body.toolbar.crm-menubar-visible.crm-menubar-below-cms-menu {
     padding-top: 70px !important;
   }
+  body.toolbar.crm-menubar-visible.crm-menubar-below-cms-menu.crm-menubar-wrapped {
+    padding-top: 110px !important;
+  }
+
   body.toolbar.toolbar-drawer.crm-menubar-visible.crm-menubar-below-cms-menu {
     padding-top: 104px !important;
+  }
+  body.toolbar.toolbar-drawer.crm-menubar-visible.crm-menubar-below-cms-menu.crm-menubar-wrapped {
+    padding-top: 144px !important;
   }
 
   body.toolbar.crm-menubar-visible.crm-menubar-below-cms-menu #toolbar {

--- a/css/menubar-drupal8.css
+++ b/css/menubar-drupal8.css
@@ -1,11 +1,16 @@
 @media (min-width: 768px) {
 
-  body.crm-menubar-visible.crm-menubar-over-cms-menu {
-    padding-top: 30px !important;
-  }
-
   body.crm-menubar-visible.crm-menubar-over-cms-menu #toolbar-administration {
     display: none;
+  }
+
+  body.crm-menubar-visible.crm-menubar-over-cms-menu {
+    padding-top: 40px !important;
+  }
+
+  body.crm-menubar-below-cms-menu > #civicrm-menu-nav ul#civicrm-menu {
+    z-index: 1000;
+    top: 40px;
   }
 
 }

--- a/css/menubar-joomla.css
+++ b/css/menubar-joomla.css
@@ -3,8 +3,15 @@
   body.crm-menubar-over-cms-menu {
     padding-top: 40px;
   }
+  body.crm-menubar-over-cms-menu.crm-menubar-wrapped {
+    padding-top: 80px;
+  }
+
   body.crm-menubar-below-cms-menu {
     margin-top: 40px;
+  }
+  body.crm-menubar-below-cms-menu.crm-menubar-wrapped {
+    margin-top: 80px;
   }
 
 }

--- a/css/menubar-joomla.css
+++ b/css/menubar-joomla.css
@@ -1,16 +1,16 @@
 @media (min-width: 768px) {
 
-  body.crm-menubar-over-cms-menu {
+  body.crm-menubar-over-cms-menu.crm-menubar-visible {
     padding-top: 40px;
   }
-  body.crm-menubar-over-cms-menu.crm-menubar-wrapped {
+  body.crm-menubar-over-cms-menu.crm-menubar-visible.crm-menubar-wrapped {
     padding-top: 80px;
   }
 
-  body.crm-menubar-below-cms-menu {
+  body.crm-menubar-below-cms-menu.crm-menubar-visible {
     margin-top: 40px;
   }
-  body.crm-menubar-below-cms-menu.crm-menubar-wrapped {
+  body.crm-menubar-below-cms-menu.crm-menubar-visible.crm-menubar-wrapped {
     margin-top: 80px;
   }
 

--- a/css/menubar-joomla.css
+++ b/css/menubar-joomla.css
@@ -1,7 +1,10 @@
 @media (min-width: 768px) {
 
+  body.crm-menubar-over-cms-menu {
+    padding-top: 40px;
+  }
   body.crm-menubar-below-cms-menu {
-    margin-top: 30px;
+    margin-top: 40px;
   }
 
 }

--- a/css/menubar-wordpress.css
+++ b/css/menubar-wordpress.css
@@ -22,10 +22,10 @@
     width: calc(100% - 36px);
   }
 
-  body.crm-menubar-below-cms-menu #wpbody {
+  body.crm-menubar-below-cms-menu.crm-menubar-visible #wpbody {
     padding-top: 40px;
   }
-  body.crm-menubar-below-cms-menu.crm-menubar-wrapped #wpbody {
+  body.crm-menubar-below-cms-menu.crm-menubar-visible.crm-menubar-wrapped #wpbody {
     padding-top: 80px;
   }
 

--- a/css/menubar-wordpress.css
+++ b/css/menubar-wordpress.css
@@ -1,26 +1,26 @@
 @media (min-width: 768px) {
 
-  body.crm-menubar-over-cms-menu #civicrm-menu {
-    padding: 1px 0;
+  body.crm-menubar-over-cms-menu.crm-menubar-visible #wpbody {
+    padding-top: 8px;
   }
 
   body.crm-menubar-over-cms-menu.crm-menubar-visible #wpadminbar {
     visibility: hidden;
   }
 
-  body.crm-menubar-below-cms-menu #civicrm-menu {
+  .wp-toolbar body.crm-menubar-below-cms-menu > #civicrm-menu-nav #civicrm-menu {
     top: 32px;
     left: 160px;
     width: calc(100% - 160px);
   }
 
-  body.crm-menubar-below-cms-menu.folded #civicrm-menu {
+  .wp-toolbar body.crm-menubar-below-cms-menu.folded > #civicrm-menu-nav #civicrm-menu {
     left: 36px;
     width: calc(100% - 36px);
   }
 
   body.crm-menubar-below-cms-menu #wpbody {
-    margin-top: 30px;
+    padding-top: 40px;
   }
 
 }
@@ -29,6 +29,13 @@
   body #civicrm-menu-nav .crm-menubar-toggle-btn {
     position: absolute;
     right: 50px;
+  }
+
+}
+@media (max-width: 600px) {
+
+  body #civicrm-menu-nav {
+    position: absolute;
   }
 
 }

--- a/css/menubar-wordpress.css
+++ b/css/menubar-wordpress.css
@@ -3,6 +3,9 @@
   body.crm-menubar-over-cms-menu.crm-menubar-visible #wpbody {
     padding-top: 8px;
   }
+  body.crm-menubar-over-cms-menu.crm-menubar-visible.crm-menubar-wrapped #wpbody {
+    padding-top: 48px;
+  }
 
   body.crm-menubar-over-cms-menu.crm-menubar-visible #wpadminbar {
     visibility: hidden;
@@ -21,6 +24,18 @@
 
   body.crm-menubar-below-cms-menu #wpbody {
     padding-top: 40px;
+  }
+  body.crm-menubar-below-cms-menu.crm-menubar-wrapped #wpbody {
+    padding-top: 80px;
+  }
+
+}
+@media (min-width: 768px) and (max-width: 960px) {
+
+  /* For the auto-fold toolbar */
+  .wp-toolbar body.crm-menubar-below-cms-menu.auto-fold > #civicrm-menu-nav #civicrm-menu {
+    left: 36px;
+    width: calc(100% - 36px);
   }
 
 }

--- a/js/crm.drupal7.js
+++ b/js/crm.drupal7.js
@@ -1,0 +1,14 @@
+// http://civicrm.org/licensing
+(function($) {
+  $(document)
+    .on('dialogopen', function(e) {
+      // D7 hack to get the toolbar out of the way (CRM-15341)
+      $('#toolbar').css('z-index', '100');
+    })
+    .on('dialogclose', function(e) {
+      if ($('.ui-dialog-content:visible').not(e.target).length < 1) {
+        // D7 hack, restore toolbar position (CRM-15341)
+        $('#toolbar').css('z-index', '');
+      }
+    });
+})(CRM.$);

--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -5,7 +5,8 @@
   CRM.menubar = _.extend({
     data: null,
     settings: {collapsibleBehavior: 'accordion'},
-    attachTo: CRM.menubar.position === 'above-crm-container' ? '#crm-container' : 'body',
+    position: 'over-cms-menu',
+    attachTo: (CRM.menubar && CRM.menubar.position === 'above-crm-container') ? '#crm-container' : 'body',
     initialize: function() {
       $('body')
         .addClass('crm-menubar-visible crm-menubar-' + CRM.menubar.position)
@@ -26,6 +27,7 @@
           CRM.menubar.hide(250, true);
         })
         .smartmenus(CRM.menubar.settings).trigger('crmLoad');
+      CRM.menubar.initializeToggle();
       CRM.menubar.initializeSearch();
       CRM.menubar.initializeMobile();
     },
@@ -155,6 +157,24 @@
     },
     refresh: function() {
       $('#civicrm-menu').smartmenus('refresh');
+    },
+    togglePosition: function() {
+      $('body').toggleClass('crm-menubar-over-cms-menu crm-menubar-below-cms-menu');
+      CRM.menubar.position = CRM.menubar.position === 'over-cms-menu' ? 'below-cms-menu' : 'over-cms-menu';
+      CRM.cache.set('menubarPosition', CRM.menubar.position);
+    },
+    initializeToggle: function() {
+      if (CRM.menubar.position === 'over-cms-menu' || CRM.menubar.position === 'below-cms-menu') {
+        $('#civicrm-menu')
+          .on('click', 'a[href="#toggle-position"]', function(e) {
+            e.preventDefault();
+            CRM.menubar.togglePosition();
+          })
+          .append('<li id="crm-menubar-toggle-position"><a href="#toggle-position" title="' + ts('Adjust menu position') + '"><i class="crm-i fa-chevron-circle-up"></i></a>');
+        if (CRM.cache.get('menubarPosition', CRM.menubar.position) !== CRM.menubar.position) {
+          CRM.menubar.togglePosition();
+        }
+      }
     },
     initializeMobile: function() {
       var $mainMenuState = $('#crm-menubar-state');

--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -186,10 +186,19 @@
         }
       })
         .on('resize', function() {
-          if ($(window).width() > 768 && $mainMenuState[0].checked) {
+          var mobileSize = $(window).width() < 768;
+          if (!mobileSize && $mainMenuState[0].checked) {
             $mainMenuState[0].click();
           }
+          if (!mobileSize && $('#civicrm-menu').height() > 50) {
+            $('body').addClass('crm-menubar-wrapped');
+          } else {
+            $('body').removeClass('crm-menubar-wrapped');
+          }
         });
+      if ($('#civicrm-menu').height() > 52) {
+        $('body').addClass('crm-menubar-wrapped');
+      }
       $mainMenuState.click(function() {
         // Use absolute position instead of fixed when open to allow scrolling menu
         var open = $(this).is(':checked');

--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -170,7 +170,7 @@
             e.preventDefault();
             CRM.menubar.togglePosition();
           })
-          .append('<li id="crm-menubar-toggle-position"><a href="#toggle-position" title="' + ts('Adjust menu position') + '"><i class="crm-i fa-chevron-circle-up"></i></a>');
+          .append('<li id="crm-menubar-toggle-position"><a href="#toggle-position" title="' + ts('Adjust menu position') + '"><i class="crm-i fa-arrow-up"></i></a>');
         if (CRM.cache.get('menubarPosition', CRM.menubar.position) !== CRM.menubar.position) {
           CRM.menubar.togglePosition();
         }

--- a/kam.php
+++ b/kam.php
@@ -45,22 +45,29 @@ function kam_civicrm_coreResourceList(&$list, $region) {
  */
 function kam_civicrm_alterContent(&$content, $context, $tplName, &$object) {
   $region = CRM_Core_Region::instance('html-header');
+  $resources = Civi::resources();
   // Remove backdrop.js file
-  $backdropJs = $region->get(Civi::resources()->getUrl('civicrm', 'js/crm.backdrop.js', TRUE));
+  $backdropJs = $region->get($resources->getUrl('civicrm', 'js/crm.backdrop.js', TRUE));
   if ($backdropJs) {
     $override = ['scriptUrl' => NULL];
     $region->update($backdropJs['name'], $override);
   }
+  // Override drupal7.js file
+  $drupal7 = $region->get($resources->getUrl('civicrm', 'js/crm.drupal7.js', TRUE));
+  if ($drupal7) {
+    $override = ['scriptUrl' => $resources->getUrl('uk.squiffle.kam', 'js/crm.drupal7.js', TRUE)];
+    $region->update($drupal7['name'], $override);
+  }
   // Override drupal8.js file
-  $drupal8 = $region->get(Civi::resources()->getUrl('civicrm', 'js/crm.drupal8.js', TRUE));
+  $drupal8 = $region->get($resources->getUrl('civicrm', 'js/crm.drupal8.js', TRUE));
   if ($drupal8) {
     $override = ['scriptUrl' => NULL];
     $region->update($drupal8['name'], $override);
   }
   // Override core joomla.css file
-  $joomlaCss = $region->get(Civi::resources()->getUrl('civicrm', 'css/joomla.css', TRUE));
+  $joomlaCss = $region->get($resources->getUrl('civicrm', 'css/joomla.css', TRUE));
   if ($joomlaCss) {
-    $override = ['styleUrl' => Civi::resources()->getUrl('uk.squiffle.kam', 'css/core-joomla.css', TRUE)];
+    $override = ['styleUrl' => $resources->getUrl('uk.squiffle.kam', 'css/core-joomla.css', TRUE)];
     $region->update($joomlaCss['name'], $override);
   }
 }


### PR DESCRIPTION
Overview
--------

* Switches to a more modern looking white/grey color scheme.
* Style improvements for WP, D8, and D7.
* Adds a toggle button so users can quickly switch between "Replace CMS menu" and "Below CMS menu" positions.
* Adds a *none* option in display preferences.

Drupal 7 Example
-------
*Note improved interaction with the shortcuts bar*
![druapl7](https://user-images.githubusercontent.com/2874912/49197901-ca38de00-f35e-11e8-9250-40d55371fd48.gif)


Wordpress Example
-------
*Note interaction with the sidebar*
![wordpress](https://user-images.githubusercontent.com/2874912/49197920-dde44480-f35e-11e8-9d07-63788bf8bb9a.gif)
