### PR TITLE
Integrate with Drupal8 toolbar

### DIFF
--- a/css/menubar-drupal8.css
+++ b/css/menubar-drupal8.css
@@ -1,11 +1,44 @@
+#toolbar-tray-civicrm {
+  display: none;
+}
+
+body.crm-menubar-visible.crm-menubar-over-cms-menu,
+body.crm-menubar-visible.crm-menubar-below-cms-menu {
+  margin-left: 0 !important;
+}
+
+nav#civicrm-menu-nav .crm-menubar-toggle-btn {
+  margin: 0;
+  position: absolute;
+  top: 0;
+  height: 38px;
+}
+#crm-menubar-state:checked ~ .crm-menubar-toggle-btn {
+  left: 0!important;
+}
+nav#civicrm-menu-nav .crm-menubar-toggle-btn span.crm-menu-logo {
+  top: 10px;
+  left: 20px;
+}
+nav#civicrm-menu-nav .crm-menubar-toggle-btn-icon {
+  left: 44px;
+}
+
 @media (min-width: 768px) {
 
-  body.crm-menubar-visible.crm-menubar-over-cms-menu #toolbar-administration {
+  body.crm-menubar-visible.crm-menubar-over-cms-menu #toolbar-administration  {
     display: none;
   }
 
   body.crm-menubar-visible.crm-menubar-over-cms-menu {
     padding-top: 40px !important;
+  }
+  body.crm-menubar-visible.crm-menubar-over-cms-menu.crm-menubar-wrapped,
+  body.crm-menubar-visible.crm-menubar-below-cms-menu {
+    padding-top: 80px !important;
+  }
+  body.crm-menubar-visible.crm-menubar-below-cms-menu.crm-menubar-wrapped {
+    padding-top: 120px !important;
   }
 
   body.crm-menubar-below-cms-menu > #civicrm-menu-nav ul#civicrm-menu {
@@ -13,4 +46,10 @@
     top: 40px;
   }
 
+}
+
+@media (max-width: 609px) {
+  nav#civicrm-menu-nav {
+    position: absolute;
+  }
 }

--- a/js/crm.drupal8.js
+++ b/js/crm.drupal8.js
@@ -1,0 +1,29 @@
+// http://civicrm.org/licensing
+
+// When on a CiviCRM page the CiviCRM toolbar tab should be active
+localStorage.setItem('Drupal.toolbar.activeTabID', JSON.stringify('toolbar-item-civicrm'));
+
+(function($) {
+  function adjustToggle() {
+    if ($(window).width() < 768) {
+      $('#civicrm-menu-nav .crm-menubar-toggle-btn').css({
+        left: '' + $('#toolbar-item-civicrm').offset().left + 'px',
+        width: '' + $('#toolbar-item-civicrm').innerWidth() + 'px'
+      });
+    }
+  }
+  $(window).resize(adjustToggle);
+  $(document).on('crmLoad', adjustToggle);
+
+  // Wait for document.ready so Drupal's jQuery is available to this script
+  $(function($) {
+    // Need Drupal's jQuery to listen to this event
+    jQuery(document).on('drupalToolbarTabChange', function(event, tab) {
+      if (CRM.menubar.position === 'below-cms-menu') {
+        var action = jQuery(tab).is('#toolbar-item-civicrm') ? 'show' : 'hide';
+        CRM.menubar[action]();
+      }
+    });
+  });
+
+})(CRM.$);

--- a/kam.php
+++ b/kam.php
@@ -68,7 +68,7 @@ function kam_civicrm_alterContent(&$content, $context, $tplName, &$object) {
   // Override drupal8.js file
   $drupal8 = $region->get($resources->getUrl('civicrm', 'js/crm.drupal8.js', TRUE));
   if ($drupal8) {
-    $override = ['scriptUrl' => NULL];
+    $override = ['scriptUrl' => $resources->getUrl('uk.squiffle.kam', 'js/crm.drupal8.js', TRUE)];
     $region->update($drupal8['name'], $override);
   }
   // Override core joomla.css file


### PR DESCRIPTION
This makes the menubar look *much* better in D8. It now acts as a toolbar tray, respecting all of D8's breakpoints for smaller screens.

Depends on https://github.com/civicrm/civicrm-drupal-8/pull/18

![drupal8](https://user-images.githubusercontent.com/2874912/49309508-771f7200-f4a9-11e8-8e83-389f473e5d1e.gif)
