### PR TITLE
WP layout & keyboard interaction fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ By default the bar will appear at the top of the screen with a toggle arrow to m
 | `removeItem( itemName )` | Deletes an item from the menu (and all its children).<br />`itemName`: name of item to remove. | `CRM.menubar.removeItem('New Household');` |
 | `show( [speed] )` | Shows the menubar if hidden.<br />`speed`: if a number is given, a slidedown animation is used. | `CRM.menubar.show(250);` |
 | `spin( [spin] )`  | Spins the icon in the home menu.<br />`spin`: pass a boolean to start or stop the spinning, or pass no arguments to toggle. | `CRM.menubar.spin(true); // start` <br /> `CRM.menubar.spin(false); // stop` |
-| `togglePosition()`  | Toggles between 'over-cms-menu' and 'below-cms-menu'. | `CRM.menubar.togglePosition();` |
+| `togglePosition( [persist] )`  | Toggles between 'over-cms-menu' and 'below-cms-menu'. By default, persist the change to localStorage. | `CRM.menubar.togglePosition();` |
 | `updateItem( item )`  | Updates the properties of a menu item (label, url, separator, icon, etc.<br />`item`: object with at least a `name` plus properties to update. | `CRM.menubar.updateItem({name: 'Search', label: 'Find'});` |
 
 Tip: Try pasting those examples into your browser console.

--- a/css/crm-menubar.css
+++ b/css/crm-menubar.css
@@ -233,7 +233,7 @@ body.crm-menubar-over-cms-menu #crm-menubar-toggle-position a i {
   }
 
   body.crm-menubar-over-cms-menu #civicrm-menu {
-    z-index: 100000;
+    z-index: 99999;
   }
 
   body.crm-menubar-hidden #civicrm-menu {

--- a/css/menubar-wordpress.css
+++ b/css/menubar-wordpress.css
@@ -28,6 +28,9 @@
   body.crm-menubar-below-cms-menu.crm-menubar-visible.crm-menubar-wrapped #wpbody {
     padding-top: 80px;
   }
+  body.crm-menubar-over-cms-menu.crm-menubar-visible.crm-menubar-wrapped #adminmenuwrap {
+    margin-top: 40px;
+  }
 
 }
 @media (min-width: 768px) and (max-width: 960px) {

--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -159,10 +159,12 @@
     refresh: function() {
       $('#civicrm-menu').smartmenus('refresh');
     },
-    togglePosition: function() {
+    togglePosition: function(persist) {
       $('body').toggleClass('crm-menubar-over-cms-menu crm-menubar-below-cms-menu');
       CRM.menubar.position = CRM.menubar.position === 'over-cms-menu' ? 'below-cms-menu' : 'over-cms-menu';
-      CRM.cache.set('menubarPosition', CRM.menubar.position);
+      if (persist !== false) {
+        CRM.cache.set('menubarPosition', CRM.menubar.position);
+      }
     },
     initializeToggle: function() {
       if (CRM.menubar.position === 'over-cms-menu' || CRM.menubar.position === 'below-cms-menu') {

--- a/js/crm.wordpress.js
+++ b/js/crm.wordpress.js
@@ -23,7 +23,7 @@ CRM.$(function($) {
     var href = $(this).attr('href');
     // Show toolbar if hidden
     if (href === '#wp-toolbar' && CRM.menubar.position === 'over-cms-menu') {
-      CRM.menubar.togglePosition();
+      CRM.menubar.togglePosition(false);
     }
     $(href).focus();
     return false;

--- a/js/crm.wordpress.js
+++ b/js/crm.wordpress.js
@@ -1,0 +1,37 @@
+// http://civicrm.org/licensing
+CRM.$(function($) {
+  $(document)
+    .on('dialogopen', function(e) {
+      // Make admin bar hide behind popup windows
+      $('#adminmenuwrap').css('z-index', '100');
+    })
+    .on('dialogclose', function(e) {
+      if ($('.ui-dialog-content:visible').not(e.target).length < 1) {
+        // Restore admin bar position
+        $('#adminmenuwrap').css('z-index', '');
+      }
+    })
+    .on('crmWysiwygCreate', function(e, type, editor) {
+      if (type === 'ckeditor') {
+        editor.on('maximize', function(e) {
+          $('#wpadminbar').toggle(e.data === 2);
+        });
+      }
+    });
+  // Prevent screen reader shortcuts from changing the document hash and breaking angular routes
+  $('a.screen-reader-shortcut').click(function() {
+    var href = $(this).attr('href');
+    // Show toolbar if hidden
+    if (href === '#wp-toolbar' && CRM.menubar.position === 'over-cms-menu') {
+      CRM.menubar.togglePosition();
+    }
+    $(href).focus();
+    return false;
+  });
+  $('<a href="#crm-qsearch-input" class="screen-reader-shortcut">' + ts("Open CiviCRM Menu") + '</a>')
+    .prependTo('#adminmenumain')
+    .click(function() {
+      CRM.menubar.open('Home');
+      return false;
+    });
+});

--- a/kam.php
+++ b/kam.php
@@ -69,6 +69,12 @@ function kam_civicrm_alterContent(&$content, $context, $tplName, &$object) {
     $override = ['scriptUrl' => $resources->getUrl('uk.squiffle.kam', 'js/crm.drupal8.js', TRUE)];
     $region->update($drupal8['name'], $override);
   }
+  // Override wordpress.js file
+  $wordpress = $region->get($resources->getUrl('civicrm', 'js/crm.wordpress.js', TRUE));
+  if ($wordpress) {
+    $override = ['scriptUrl' => $resources->getUrl('uk.squiffle.kam', 'js/crm.wordpress.js', TRUE)];
+    $region->update($wordpress['name'], $override);
+  }
   // Override core joomla.css file
   $joomlaCss = $region->get($resources->getUrl('civicrm', 'css/joomla.css', TRUE));
   if ($joomlaCss) {


### PR DESCRIPTION
- Fixes menubar to not block WP sidebar when wrapped to 2 lines.
- Decrement civi menubar z-index for WP screenreader links to show through.
- Adds a screenreader link to the CiviCRM menu.
- Moves the Civi menu out of the way when selecting the "Skip to toolbar" wp screenreader link.
- Intercepts WP screenreader links so they don't change the document hash and break Angular routes.