### PR TITLE
Add access keys for menubar

### DIFF
--- a/CRM/Kam/Page/AJAX.php
+++ b/CRM/Kam/Page/AJAX.php
@@ -82,6 +82,7 @@ class CRM_Kam_Page_AJAX {
       if (CRM_Utils_Array::value('name', $item['attributes']) === 'Home') {
         unset($item['attributes']['label'], $item['attributes']['url']);
         $item['attributes']['icon'] = 'crm-logo-sm';
+        $item['attributes']['attr']['accesskey'] = 'm';
         $item['child'] = [
           [
             'attributes' => [

--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -58,6 +58,10 @@
               e.preventDefault();
               CRM.menubar.hide(250, true);
             })
+            .on('show.smapi', function(e, menu) {
+              // Focus menu when opened with an accesskey
+              $(menu).siblings('a[accesskey]:not(:hover)').focus();
+            })
             .smartmenus(CRM.menubar.settings);
           initialized = true;
           CRM.menubar.initializeResponsive();
@@ -363,7 +367,7 @@
         '<a href="#"> ' +
           '<form action="<%= CRM.url(\'civicrm/contact/search/advanced\') %>" name="search_block" method="post">' +
             '<div>' +
-              '<input type="text" id="crm-qsearch-input" name="sort_name" placeholder="\uf002" />' +
+              '<input type="text" id="crm-qsearch-input" name="sort_name" placeholder="\uf002" accesskey="q" />' +
               '<input type="hidden" name="hidden_location" value="1" />' +
               '<input type="hidden" name="hidden_custom" value="1" />' +
               '<input type="hidden" name="qfKey" value="<%= CRM.menubar.qfKey %>" />' +
@@ -379,8 +383,8 @@
       '</li>',
     branchTpl:
       '<% _.forEach(items, function(item) { %>' +
-        '<li <%= attr(item) %>>' +
-          '<a href="<%= item.url || "#" %>">' +
+        '<li <%= attr("li", item) %>>' +
+          '<a <%= attr("a", item) %>>' +
             '<% if (item.icon) { %>' +
               '<i class="<%- item.icon %>"></i>' +
             '<% } %>' +
@@ -434,11 +438,17 @@
     return found;
   }
 
-  function attr(item) {
-    var ret = [], attr = _.cloneDeep(item.attr || {});
-    attr['data-name'] = item.name;
-    if (item.separator) {
-      attr.class = (attr.class ? attr.class + ' ' : '') + 'crm-menu-border-' + item.separator;
+  function attr(el, item) {
+    var ret = [], attr = _.cloneDeep(item.attr || {}), a = ['rel', 'accesskey'];
+    if (el === 'a') {
+      attr = _.pick(attr, a);
+      attr.href = item.url || "#";
+    } else {
+      attr = _.omit(attr, a);
+      attr['data-name'] = item.name;
+      if (item.separator) {
+        attr.class = (attr.class ? attr.class + ' ' : '') + 'crm-menu-border-' + item.separator;
+      }
     }
     _.each(attr, function(val, name) {
       ret.push(name + '="' + val + '"');

--- a/templates/CRM/common/accesskeys.hlp
+++ b/templates/CRM/common/accesskeys.hlp
@@ -1,0 +1,60 @@
+{*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2018                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*}
+{htxt id="accesskeys-title"}
+  {ts}Access Keys{/ts}
+{/htxt}
+{htxt id="accesskeys"}
+  {php}
+    $ua = strtolower($_SERVER['HTTP_USER_AGENT']);
+    if (strstr($ua, 'mac')) {
+      $key = '<span>CTRL</span>+<span>ALT</span>';
+    }
+    else {
+      $key = strstr($ua, 'firefox') ? '<span>ALT</span>+<span>SHIFT</span>' : '<span>ALT</span>';
+    }
+    $this->assign('accessKey', $key);
+  {/php}
+  <p></p>
+  <ul id="crmAccessKeyList">
+    <li>{$accessKey}+<span>E</span> - {ts}Edit Contact (View Contact Summary Page){/ts}</li>
+    <li>{$accessKey}+<span>S</span> - {ts}Save Button{/ts}</li>
+    <li>{$accessKey}+<span>N</span> - {ts}Add a new record in each tab (Activities, Tags,..etc){/ts}</li>
+    <li>{$accessKey}+<span>M</span> - {ts}Open the CiviCRM menubar{/ts}</li>
+    <li>{$accessKey}+<span>Q</span> - {ts}Quicksearch{/ts}</li>
+  </ul>
+  {literal}<style type="text/css">
+    #crmAccessKeyList li {
+      margin-top: 5px;
+    }
+    #crmAccessKeyList span {
+      display: inline-block;
+      background: grey;
+      font-size: 80%;
+      border: 2px groove #eee;
+      padding: 0 4px;
+    }
+  </style>{/literal}
+{/htxt}


### PR DESCRIPTION
There have been a few suggestions to add accessKeys to make it eaiser to get to the menubar. This is the result.

- Add shortcut keys for the home menu ("M") and the quicksearch box ("Q").
- Improve the styling of the access keys help popup
- Actually show the correct modifier keys! (before it was hardcoded to Firefox on Win/Linux and incorrect for every other browser!)

![screenshot from 2018-12-20 11-14-24](https://user-images.githubusercontent.com/2874912/50296626-e523dd00-0448-11e9-8a11-7f7550b0deb4.png)
