### PR TITLE
Fix #49 - Prevent dragging menu items into the quicksearch box

### DIFF
--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -61,6 +61,11 @@
                 e.stopPropagation();
               }
             })
+            .on('dragstart', function() {
+              // Stop user from accidentally dragging menu links
+              // This was added because a user noticed they could drag the civi icon into the quicksearch box.
+              return false;
+            })
             .on('click', 'a[href="#hidemenu"]', function(e) {
               e.preventDefault();
               CRM.menubar.hide(250, true);


### PR DESCRIPTION
Fixes #49

This solution may be a bit heavy-handed as it prevents dragging any menu item anywhere.
But for the life of me I can't think of any reason why someone would want to do that.